### PR TITLE
Update README.md with correct top level directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@ Electron will automatically launch and update itself when your source code chang
 ## File Structure
 We use the component approach in our starter. This is the new standard for developing Angular apps and a great way to ensure maintainable code by encapsulation of our behavior logic. A component is basically a self contained app usually in a single file or a folder with each concern as a file: style, template, specs, e2e, and component class. Here's how it looks:
 ```
-angular2-webpack-starter/
+angular-electron-dream-starter/
  ├──config/                        * our configuration
  |   ├──helpers.js                 * helper functions for our configuration files
  |   ├──spec-bundle.js             * ignore this magic that sets up our Angular testing environment


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
docs update


* **What is the current behavior?** (You can also link to an open issue here)
Currently list 'angular2-electron-starter' for top level directory.


* **What is the new behavior (if this is a feature change)?**
List 'angular-electron-dream-starter' as the top level directory


* **Other information**:
