### PR TITLE
Fixing DevTools 'No Store Found' Issue

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -71,10 +71,11 @@ let CONDITIONAL_IMPORTS = [];
 
 if (ENV === 'development') {
   console.log('loading react devtools');
-  CONDITIONAL_IMPORTS.push(StoreDevtoolsModule.instrument());
   // AoT won't allow metaReducers, so we need to add them conditionally
   // this should override the previous StoreModule declaration
   CONDITIONAL_IMPORTS.push(StoreModule.forRoot(reducers, { metaReducers }));
+  // Now connecting to DevModule.
+  CONDITIONAL_IMPORTS.push(StoreDevtoolsModule.instrument());
 }
 
 /**


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

It solves the DevTools Order issue

* **What is the current behavior?** (You can also link to an open issue here)

Currently, the redux tab shows "no store found"

* **What is the new behavior (if this is a feature change)?**

Can correctly see the devtools

* **Other information**:
