### PR TITLE
fix npm install of electron-builder

### DIFF
--- a/config/install-app-deps.js
+++ b/config/install-app-deps.js
@@ -1,6 +1,8 @@
 const fs = require('fs');
 const path = require('path');
-const installOrRebuild = require('electron-builder/out/util/yarn').installOrRebuild;
+const installOrRebuild = fs.existsSync('electron-builder/out/util/yarn')
+  ? require('electron-builder/out/util/yarn').installOrRebuild
+  : require('electron-builder-lib/out/util/yarn').installOrRebuild;
 const printErrorAndExit = require('builder-util/out/promise').printErrorAndExit;
 
 const root = process.cwd();
@@ -34,7 +36,7 @@ function getElectronVersion(root) {
 }
 
 function writeAppPackage(metadata, appDir) {
-  const fields = ['name', 'productName', 'version', 'description', 'keywords', 
+  const fields = ['name', 'productName', 'version', 'description', 'keywords',
         'author', 'homepage', 'license', 'dependencies'];
   var output = {};
   fields.forEach(function(field) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3847,6 +3847,10 @@ karma-sourcemap-loader@^0.3.7:
   dependencies:
     graceful-fs "^4.1.2"
 
+karma-webpack-grep@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/karma-webpack-grep/-/karma-webpack-grep-1.0.1.tgz#c8e6eb321b058e10cb600b4bf68be369a2458c86"
+
 karma-webpack@~2.0.3:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/karma-webpack/-/karma-webpack-2.0.4.tgz#3e2d4f48ba94a878e1c66bb8e1ae6128987a175b"


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Fixes difference in versions of `electron-builder` structure when using `npm` instead of `yarn` to install.


* **What is the current behavior?** (You can also link to an open issue here)
Currently if you install with npm you get a different structure of dependencies compared to yarn install


* **What is the new behavior (if this is a feature change)?**
fixes script require based on the two versions possibly installed.


* **Other information**:
Another option exists but would require additional changes to refactor the build process to use the `electron-builder` cli commands.